### PR TITLE
0.6.0 Support Kernel::puts with table output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,25 @@ require 'tablesmith'
 | 1 | 2 |
 +---+---+
    
-> [{date: '1/1/2020', amt: 35}, {date: '1/2/2020', amt: 80}].to_table
+> t = [{date: '1/1/2020', amt: 35}, {date: '1/2/2020', amt: 80}].to_table
 => +----------+-----+
 |   date   | amt |
 +----------+-----+
 | 1/1/2020 | 35  |
 | 1/2/2020 | 80  |
 +----------+-----+
+                                    
+> # Table delegates to Array, all Array methods are available.
+> t.select! { |h| h[:amt] > 40 }    
+=> [{:date=>"1/2/2020", :amt=>80}]
+
+> t
+=> +----------+-----+
+|   date   | amt |
++----------+-----+
+| 1/2/2020 | 80  |
++----------+-----+
+
            
 > p1 = Person.create(first_name: 'chrismo', custom_attributes: { instrument: 'piano', style: 'jazz' })    
 => #<Person:0x00007fac3eb406a8 id: 1, first_name: "chrismo", last_name: nil, age: nil, custom_attributes: {:instrument=>"piano", :style=>"jazz"}>

--- a/lib/tablesmith.rb
+++ b/lib/tablesmith.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'tablesmith/delegated_array_class'
 require 'tablesmith/table'
 require 'tablesmith/array_rows_source'
 require 'tablesmith/hash_rows_base'

--- a/lib/tablesmith/delegated_array_class.rb
+++ b/lib/tablesmith/delegated_array_class.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Tablesmith
+  # This adjustment to `DelegateClass(Array)` is necessary to allow calling puts
+  # on a `Tablesmith::Table` and still get the table output, rather than the
+  # default puts output of the underlying `Array`.
+  #
+  # Explaining why requires breaking some things down.
+  #
+  # The implementation of `Kernel::puts` has special code for an `Array`. The
+  # code inside `rb_io_puts` (in io.c) first checks to see if the object passed
+  # to it is a `String`. If not, it then calls `io_puts_ary`, which in turn
+  # calls `rb_check_array_type`. If `rb_check_array_type` confirms the passed
+  # object is an `Array`, then `io_puts_ary` loops over the elements of the
+  # `Array` and passes it to `rb_io_puts`. If the `Array` check fails in the
+  # original `rb_io_puts`, `rb_obj_as_string` is used.
+  #
+  # Early versions of `Tablesmith::Table` subclassed `Array`, but even after
+  # changing `Tablesmith::Table` to use any of the `Delegator` options, the code
+  # in `rb_check_array_type` still detected `Tablesmith::Table` as an `Array`.
+  # How does it do this?
+  #
+  # `rb_check_array_type` calls:
+  #
+  #   `return rb_check_convert_type_with_id(ary, T_ARRAY, "Array", idTo_ary);`
+  #
+  # If a straight up type check fails, then it attempts to convert the object to
+  # an `Array` via the `to_ary` method.
+  #
+  # And wha-lah. We simply need to undefine the `to_ary` method added to
+  # `Tablesmith::Table` by `DelegateClass(Array)` and `rb_io_puts` will no
+  # longer output `Table` as an `Array` and will use its `to_s` method, the same
+  # as `print`.
+  def self.delegated_array_class
+    DelegateClass(Array).tap do |klass|
+      klass.undef_method(:to_ary)
+    end
+  end
+end

--- a/lib/tablesmith/table.rb
+++ b/lib/tablesmith/table.rb
@@ -4,18 +4,25 @@ require 'text-table'
 require 'csv'
 
 module Tablesmith
-  class Table < Array
+  class Table < Tablesmith.delegated_array_class
+    def initialize(array = [])
+      super(array)
+      @array = array
+    end
+
+    # This method_missing is _not_ part of the delegation to the wrapped Array
+    # instance. It's an additional convenience that allows you to call a method
+    # against every instance inside the array with needing to call map. Though
+    # ... this may go away, calling map isn't that hard.
     def method_missing(meth_id, *args)
+      return nil if meth_id == :to_ary
+
       count = 1
-      map do |t|
+      @array.map do |t|
         $stderr.print '.' if (count.divmod(100)[1]).zero?
         count += 1
         t.send(meth_id, *args)
       end
-    end
-
-    def respond_to_missing?
-      super
     end
 
     def to_s

--- a/lib/tablesmith/table.rb
+++ b/lib/tablesmith/table.rb
@@ -10,19 +10,19 @@ module Tablesmith
       @array = array
     end
 
-    # This method_missing is _not_ part of the delegation to the wrapped Array
-    # instance. It's an additional convenience that allows you to call a method
-    # against every instance inside the array with needing to call map. Though
-    # ... this may go away, calling map isn't that hard.
     def method_missing(meth_id, *args)
+      # In order to support `Kernel::puts` of a `Table`, we need to ignore
+      # `to_ary` calls here as well. See comments on `delegated_array_class`.
+      #
+      # While `DelegatorClass(Array)` proactively defines methods on `Table`
+      # that come from `Array`, it _also_ will pass calls through method_missing
+      # to the target object if it says it will respond to it.
+      #
+      # It seems a little redundant, but it is what it is, and so we must also
+      # cut off calls to `to_ary` in both places.
       return nil if meth_id == :to_ary
 
-      count = 1
-      @array.map do |t|
-        $stderr.print '.' if (count.divmod(100)[1]).zero?
-        count += 1
-        t.send(meth_id, *args)
-      end
+      super
     end
 
     def to_s

--- a/lib/tablesmith/version.rb
+++ b/lib/tablesmith/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Tablesmith
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end

--- a/spec/array_table_spec.rb
+++ b/spec/array_table_spec.rb
@@ -14,7 +14,7 @@ describe 'Array Source' do
     [%w[a b c], %w[d e f]].to_table.to_s.should == expected
   end
 
-  def do_just_works_test(_expected, meth_id)
+  def do_just_works_test(meth_id)
     orig_stdout = $stdout
     sio = StringIO.new
     $stdout = sio
@@ -33,7 +33,7 @@ describe 'Array Source' do
       +---+---+---+
     TABLE
 
-    actual = do_just_works_test(expected, meth_id)
+    actual = do_just_works_test(meth_id)
     actual.should == expected
   end
 
@@ -43,6 +43,19 @@ describe 'Array Source' do
 
   it 'just works with puts' do
     just_works(:puts)
+  end
+
+  it 'just works with p' do
+    expected = <<~TABLE
+      +---+---+---+
+      | a | b | c |
+      +---+---+---+
+      | d | e | f |
+      +---+---+---+
+    TABLE
+
+    actual = do_just_works_test(:p)
+    actual.should == "#{expected}\n"
   end
 
   it 'just works with inspect' do

--- a/spec/array_table_spec.rb
+++ b/spec/array_table_spec.rb
@@ -42,11 +42,6 @@ describe 'Array Source' do
   end
 
   it 'just works with puts' do
-    pending
-
-    # Kernel.puts has special behavior for puts with Array,
-    # which Table subclasses, so this isn't going to work,
-    # unless we can stop subclassing Array.
     just_works(:puts)
   end
 

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 include Tablesmith # rubocop:disable Style/MixinUsage:
 
 describe Table do
-  it 'should subclass array' do
+  it 'should delegate to the internal array' do
     b = Table.new
     b.length.should == 0
     b << 1
@@ -29,7 +29,7 @@ describe Table do
       | (empty) |
       +---------+
     TEXT
-    [].to_table.text_table.to_s.should == expected
+    [].to_table.to_s.should == expected
   end
 
   it 'should handle a simple two row Array' do
@@ -42,7 +42,7 @@ describe Table do
       | d | e | f |
       +---+---+---+
     TABLE
-    actual.to_table.text_table.to_s.should == expected
+    actual.to_table.to_s.should == expected
   end
 
   it 'should output csv' do

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -15,12 +15,18 @@ describe Table do
     b.class.should == Table
   end
 
-  it 'should pass unmatched Array messages to all items' do
+  it 'should no longer pass unmatched Array messages to all items' do
+
+    # earlier pre-1.0 versions implemented method_missing in order to provide
+    # syntactic sugar for calling map on the underlying Array. But as time went
+    # on, it felt too heavy-handed and not worth it.
+
     b = Table.new
     b.length.should == 0
     b << 1
     b << '2'
-    b.to_i.should == [1, 2]
+    b.map(&:to_i).should == [1, 2]
+    -> { b.to_i }.should raise_error(NoMethodError)
   end
 
   it 'should handle empty Array' do


### PR DESCRIPTION
There's a lengthy explanation in the code. Check it out.

(copy/pasted here):

This adjustment to `DelegateClass(Array)` is necessary to allow calling puts
on a `Tablesmith::Table` and still get the table output, rather than the
default puts output of the underlying `Array`.

Explaining why requires breaking some things down.

The implementation of `Kernel::puts` has special code for an `Array`. The
code inside `rb_io_puts` (in io.c) first checks to see if the object passed
to it is a `String`. If not, it then calls `io_puts_ary`, which in turn
calls `rb_check_array_type`. If `rb_check_array_type` confirms the passed
object is an `Array`, then `io_puts_ary` loops over the elements of the
`Array` and passes it to `rb_io_puts`. If the `Array` check fails in the
original `rb_io_puts`, `rb_obj_as_string` is used.

Early versions of `Tablesmith::Table` subclassed `Array`, but even after
changing `Tablesmith::Table` to use any of the `Delegator` options, the code
in `rb_check_array_type` still detected `Tablesmith::Table` as an `Array`.
How does it do this?

`rb_check_array_type` calls:

  `return rb_check_convert_type_with_id(ary, T_ARRAY, "Array", idTo_ary);`

If a straight up type check fails, then it attempts to convert the object to
an `Array` via the `to_ary` method.

And wha-lah. We simply need to undefine the `to_ary` method added to
`Tablesmith::Table` by `DelegateClass(Array)` and `rb_io_puts` will no
longer output `Table` as an `Array` and will use its `to_s` method, the same
as `print`.
